### PR TITLE
Allow for limiting tables to a db schema during field introspection

### DIFF
--- a/lib/DBIx/SearchBuilder/Handle.pm
+++ b/lib/DBIx/SearchBuilder/Handle.pm
@@ -9,7 +9,7 @@ use DBI;
 use Class::ReturnValue;
 use Encode qw();
 
-use vars qw(@ISA %DBIHandle $PrevHandle $DEBUG %TRANSDEPTH %FIELDS_IN_TABLE);
+use vars qw(@ISA %DBIHandle $PrevHandle $DEBUG %TRANSDEPTH %FIELDS_IN_TABLE $DBSchema);
 
 
 =head1 NAME
@@ -1411,8 +1411,9 @@ sub Fields {
     my $self  = shift;
     my $table = shift;
 
+    my $schema = defined($DBSchema) ? $DBSchema : '';
     unless ( keys %FIELDS_IN_TABLE ) {
-        my $sth = $self->dbh->column_info( undef, '', '%', '%' )
+        my $sth = $self->dbh->column_info( undef, $schema, '%', '%' )
             or return ();
         my $info = $sth->fetchall_arrayref({});
         foreach my $e ( @$info ) {

--- a/t/20namespace.t
+++ b/t/20namespace.t
@@ -1,0 +1,118 @@
+#!/usr/bin/perl -w
+
+use strict;
+use warnings;
+use Test::More;
+
+use constant TESTS_PER_DRIVER => 4;
+
+our @AvailableDrivers;
+BEGIN { require "t/utils.pl" }
+
+use DBIx::SearchBuilder::Handle;
+
+my $total = scalar(@AvailableDrivers) * TESTS_PER_DRIVER;
+plan tests => $total;
+
+foreach my $d ( @AvailableDrivers ) {
+SKIP: {
+    unless ($d eq 'Pg') {
+        skip "first goal is to work on Pg", TESTS_PER_DRIVER;
+    }
+	unless( should_test( $d ) ) {
+		skip "ENV is not defined for driver '$d'", TESTS_PER_DRIVER;
+	}
+
+    my $handle = get_handle( $d );
+    connect_handle( $handle );
+    init_schema( 'TestApp::Address', $handle );
+
+    is_deeply(
+        [$handle->Fields('Address')],
+        [qw(id name phone employeeid)],
+        "listed all columns in the table for $d"
+    );
+    is_deeply(
+        [$handle->Fields('Other')],
+        ['id'],
+        "'Other' is not seen when a schema is specified"
+    );
+
+    $handle->dbh(undef);
+    connect_handle( $handle );
+    local $DBIx::SearchBuilder::Handle::DBSchema = 'public';
+
+    is_deeply(
+        [$handle->Fields('Address')],
+        [qw(id name phone employeeid)],
+        "listed all columns in the table for $d"
+    );
+    is_deeply(
+        [$handle->Fields('Other')],
+        [],
+        "'Other' is not seen when a schema is specified"
+    );
+
+	cleanup_schema( 'TestApp::Address', $handle );
+}} # SKIP, foreach blocks
+
+1;
+
+
+
+package TestApp::Address;
+
+use base $ENV{SB_TEST_CACHABLE}?
+    qw/DBIx::SearchBuilder::Record::Cachable/:
+    qw/DBIx::SearchBuilder::Record/;
+
+sub _Init {
+    my $self = shift;
+    my $handle = shift;
+    $self->Table('Address');
+    $self->_Handle($handle);
+}
+
+sub ValidateName
+{
+	my ($self, $value) = @_;
+	return 0 if $value =~ /invalid/i;
+	return 1;
+}
+
+sub _ClassAccessible {
+
+    {
+        id =>
+        {read => 1, type => 'int(11)', default => ''},
+        Name =>
+        {read => 1, write => 1, type => 'varchar(14)', default => ''},
+        Phone =>
+        {read => 1, write => 1, type => 'varchar(18)', length => 18, default => ''},
+        EmployeeId =>
+        {read => 1, write => 1, type => 'int(8)', default => ''},
+    }
+
+}
+
+sub schema_pg {
+<<EOF;
+CREATE SCHEMA otherapp CREATE TABLE Other (id serial PRIMARY KEY);
+CREATE TABLE public.Address (
+        id serial PRIMARY KEY,
+        Name varchar,
+        Phone varchar,
+        EmployeeId integer
+);
+EOF
+}
+
+# Can't create temporary tables in a schema
+sub cleanup_schema_pg {
+<<EOF;
+DROP SCHEMA otherapp CASCADE;
+DROP TABLE public.Address;
+EOF
+}
+
+1;


### PR DESCRIPTION
If the user intends to use DBIx::SB for only a specific schema, this can
save some time on the initial field population process.
