### PR TITLE
Fix for '.' removal from @INC in Perl 5.26

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,3 +1,4 @@
+use lib '.';
 use inc::Module::Install;
 
 name ('DBIx-SearchBuilder');

--- a/t/01basics.t
+++ b/t/01basics.t
@@ -3,7 +3,7 @@
 use strict;
 
 use Test::More;
-BEGIN { require "t/utils.pl" }
+BEGIN { require "./t/utils.pl" }
 our (@AvailableDrivers);
 
 use constant TESTS_PER_DRIVER => 4;

--- a/t/01nocap_api.t
+++ b/t/01nocap_api.t
@@ -3,7 +3,7 @@
 use strict;
 
 use Test::More;
-BEGIN { require "t/utils.pl" }
+BEGIN { require "./t/utils.pl" }
 
 use vars qw(@SPEC_METHODS @MODULES);
 my @SPEC_METHODS = qw(AUTOLOAD DESTROY CLONE);

--- a/t/01records.t
+++ b/t/01records.t
@@ -4,7 +4,7 @@
 use strict;
 use warnings;
 use Test::More;
-BEGIN { require "t/utils.pl" }
+BEGIN { require "./t/utils.pl" }
 our (@AvailableDrivers);
 
 use constant TESTS_PER_DRIVER => 66;

--- a/t/01searches.t
+++ b/t/01searches.t
@@ -4,7 +4,7 @@
 use strict;
 use warnings;
 use Test::More;
-BEGIN { require "t/utils.pl" }
+BEGIN { require "./t/utils.pl" }
 our (@AvailableDrivers);
 
 use constant TESTS_PER_DRIVER => 150;

--- a/t/02distinct_values.t
+++ b/t/02distinct_values.t
@@ -4,7 +4,7 @@
 use strict;
 use warnings;
 use Test::More;
-BEGIN { require "t/utils.pl" }
+BEGIN { require "./t/utils.pl" }
 our (@AvailableDrivers);
 
 use constant TESTS_PER_DRIVER => 9;

--- a/t/02null_order.t
+++ b/t/02null_order.t
@@ -4,7 +4,7 @@
 use strict;
 use warnings;
 use Test::More;
-BEGIN { require "t/utils.pl" }
+BEGIN { require "./t/utils.pl" }
 our (@AvailableDrivers);
 
 use constant TESTS_PER_DRIVER => 11;

--- a/t/02order_outer.t
+++ b/t/02order_outer.t
@@ -4,7 +4,7 @@
 use strict;
 use warnings;
 use Test::More;
-BEGIN { require "t/utils.pl" }
+BEGIN { require "./t/utils.pl" }
 our (@AvailableDrivers);
 
 use constant TESTS_PER_DRIVER => 98;

--- a/t/02records_cachable.t
+++ b/t/02records_cachable.t
@@ -4,7 +4,7 @@
 use strict;
 use warnings;
 use Test::More;
-BEGIN { require "t/utils.pl" }
+BEGIN { require "./t/utils.pl" }
 our (@AvailableDrivers);
 
 use constant TESTS_PER_DRIVER => 16;

--- a/t/02records_datetime.t
+++ b/t/02records_datetime.t
@@ -5,7 +5,7 @@ BEGIN { $ENV{'TZ'} = 'Europe/Moscow' };
 use strict;
 use warnings;
 use Test::More;
-BEGIN { require "t/utils.pl" }
+BEGIN { require "./t/utils.pl" }
 our (@AvailableDrivers);
 
 use constant TESTS_PER_DRIVER => 38;

--- a/t/02records_dt_interval.t
+++ b/t/02records_dt_interval.t
@@ -5,7 +5,7 @@ BEGIN { $ENV{'TZ'} = 'Europe/Moscow' };
 use strict;
 use warnings;
 use Test::More;
-BEGIN { require "t/utils.pl" }
+BEGIN { require "./t/utils.pl" }
 our (@AvailableDrivers);
 
 use constant TESTS_PER_DRIVER => 17;

--- a/t/02records_integers.t
+++ b/t/02records_integers.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 use Test::More;
-BEGIN { require "t/utils.pl" }
+BEGIN { require "./t/utils.pl" }
 our (@AvailableDrivers);
 
 use constant TESTS_PER_DRIVER => 37;

--- a/t/02records_object.t
+++ b/t/02records_object.t
@@ -5,7 +5,7 @@ use strict;
 use warnings;
 use Test::More;
 
-BEGIN { require "t/utils.pl" }
+BEGIN { require "./t/utils.pl" }
 our (@AvailableDrivers);
 
 use constant TESTS_PER_DRIVER => 11;

--- a/t/02searches_function.t
+++ b/t/02searches_function.t
@@ -3,7 +3,7 @@
 use strict;
 use Test::More;
 
-BEGIN { require "t/utils.pl" }
+BEGIN { require "./t/utils.pl" }
 our (@AvailableDrivers);
 
 use constant TESTS_PER_DRIVER => 18;

--- a/t/02searches_joins.t
+++ b/t/02searches_joins.t
@@ -3,7 +3,7 @@
 use strict;
 use Test::More;
 
-BEGIN { require "t/utils.pl" }
+BEGIN { require "./t/utils.pl" }
 our (@AvailableDrivers);
 
 use constant TESTS_PER_DRIVER => 59;

--- a/t/03compatibility.t
+++ b/t/03compatibility.t
@@ -4,7 +4,7 @@
 use strict;
 use warnings;
 use Test::More;
-BEGIN { require "t/utils.pl" }
+BEGIN { require "./t/utils.pl" }
 our (@AvailableDrivers);
 
 use constant TESTS_PER_DRIVER => 2;

--- a/t/03cud_from_select.t
+++ b/t/03cud_from_select.t
@@ -3,7 +3,7 @@
 use strict;
 use Test::More;
 
-BEGIN { require "t/utils.pl" }
+BEGIN { require "./t/utils.pl" }
 our (@AvailableDrivers);
 
 use constant TESTS_PER_DRIVER => 14;

--- a/t/03rebless.t
+++ b/t/03rebless.t
@@ -6,7 +6,7 @@ use warnings;
 use Test::More;
 use DBIx::SearchBuilder::Handle;
 
-BEGIN { require "t/utils.pl" }
+BEGIN { require "./t/utils.pl" }
 our (@AvailableDrivers);
 
 use constant TESTS_PER_DRIVER => 4;

--- a/t/03transactions.t
+++ b/t/03transactions.t
@@ -4,7 +4,7 @@
 use strict;
 use warnings;
 use Test::More;
-BEGIN { require "t/utils.pl" }
+BEGIN { require "./t/utils.pl" }
 our (@AvailableDrivers);
 
 use constant TESTS_PER_DRIVER => 52;

--- a/t/03versions.t
+++ b/t/03versions.t
@@ -5,7 +5,7 @@ use warnings;
 use Test::More;
 use DBIx::SearchBuilder::Handle;
 
-BEGIN { require "t/utils.pl" }
+BEGIN { require "./t/utils.pl" }
 our (@AvailableDrivers);
 
 use constant TESTS_PER_DRIVER => 6;

--- a/t/10schema.t
+++ b/t/10schema.t
@@ -8,7 +8,7 @@ use constant TESTS_PER_DRIVER => 14;
 our @AvailableDrivers;
 
 BEGIN {
-  require("t/utils.pl");
+  require("./t/utils.pl");
   my $total = 3 + scalar(@AvailableDrivers) * TESTS_PER_DRIVER;
   if( not eval { require DBIx::DBSchema } ) {
     plan skip_all => "DBIx::DBSchema not installed";
@@ -22,7 +22,7 @@ BEGIN {
   use_ok("DBIx::SearchBuilder::Handle");
 }
 
-require_ok("t/testmodels.pl");
+require_ok("./t/testmodels.pl");
 
 foreach my $d ( @AvailableDrivers ) {
   SKIP: {

--- a/t/11schema_records.t
+++ b/t/11schema_records.t
@@ -5,7 +5,7 @@ use strict;
 use warnings;
 use Test::More;
 
-BEGIN { require "t/utils.pl" }
+BEGIN { require "./t/utils.pl" }
 our (@AvailableDrivers);
 
 use constant TESTS_PER_DRIVER => 63;

--- a/t/20set_edge_cases.t
+++ b/t/20set_edge_cases.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 use Test::More;
-BEGIN { require "t/utils.pl" }
+BEGIN { require "./t/utils.pl" }
 our (@AvailableDrivers);
 
 use constant TESTS_PER_DRIVER => 20;


### PR DESCRIPTION
Bug: https://rt.cpan.org/Ticket/Display.html?id=121140
Bug: https://bugs.gentoo.org/615602